### PR TITLE
Fix unclosed file in resources _inline()

### DIFF
--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -290,7 +290,8 @@ class BaseResources(object):
 
     def _inline(self, path):
         begin = "/* BEGIN %s */" % path
-        middle = open(path, 'rb').read().decode("utf-8")
+        with open(path, 'rb') as f:
+            middle = f.read().decode("utf-8")
         end = "/* END %s */" % path
         return "%s\n%s\n%s" % (begin, middle, end)
 


### PR DESCRIPTION
Raises ResourceWarning in python 3.4.